### PR TITLE
TauriTavern: Update to version 2.2.0

### DIFF
--- a/bucket/TauriTavern.json
+++ b/bucket/TauriTavern.json
@@ -1,5 +1,5 @@
 {
-    "version": "2.1.1",
+    "version": "2.2.0",
     "description": "A native SillyTavern client for desktop and mobile, built with Tauri and Rust.",
     "homepage": "https://github.com/Darkatse/TauriTavern",
     "license": "AGPL-3.0-only",
@@ -8,8 +8,8 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/Darkatse/TauriTavern/releases/download/v2.1.1/TauriTavern-windows-x64-portable.exe#/TauriTavern.exe",
-            "hash": "7f2ed8a9e0e013910f02091a772ce15ef74123233a50ad94783e4e4bee2e8939"
+            "url": "https://github.com/Darkatse/TauriTavern/releases/download/v2.2.0/TauriTavern-2.2.0-windows-x64-portable.exe#/TauriTavern.exe",
+            "hash": "964c1f191276edc53a94b3ab571c4d7225a0499f9a41ae415197c70c8eac4f5a"
         }
     },
     "pre_install": [
@@ -31,12 +31,14 @@
         "tauritavern-runtime.json"
     ],
     "checkver": {
-        "github": "https://github.com/Darkatse/TauriTavern"
+        "url": "https://api.github.com/repos/Darkatse/TauriTavern/releases/latest",
+        "jsonpath": "$.assets[*].browser_download_url",
+        "regex": "releases/download/v([\\d.]+)/TauriTavern-[\\d.]+-windows-x64-portable\\.exe"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/Darkatse/TauriTavern/releases/download/v$version/TauriTavern-windows-x64-portable.exe#/TauriTavern.exe"
+                "url": "https://github.com/Darkatse/TauriTavern/releases/download/v$version/TauriTavern-$version-windows-x64-portable.exe#/TauriTavern.exe"
             }
         }
     }


### PR DESCRIPTION
## Summary

- update TauriTavern to 2.2.0
- follow the new versioned Windows portable asset name
- detect updates only after the matching portable asset is present in the latest stable release

## Validation

- validated the manifest as JSON
- matched checkver against the v2.2.0 release API response
- verified the autoupdate URL and GitHub SHA-256 digest
